### PR TITLE
Fix icon display issue by adding "icons" field in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,12 @@
   "background": {
     "service_worker": "background.js"
   },
+  "icons": {
+    "16": "images/icon16.png",
+    "32": "images/icon32.png",
+    "48": "images/icon48.png",
+    "128": "images/icon128.png"
+  },
   "action": {
     "default_popup": "popup.html",
     "default_icon": {


### PR DESCRIPTION
Resolved the issue where extension icons were not displaying by adding the "icons" field at the top level of the manifest.json file. This ensures the icons are correctly loaded and displayed in the Chrome extension interface.